### PR TITLE
Added Attr field selector to Payload.Session class

### DIFF
--- a/src/Payload/Payload.csproj
+++ b/src/Payload/Payload.csproj
@@ -4,8 +4,8 @@
     <RootNamespace>Payload</RootNamespace>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <AssemblyTitle>Payload</AssemblyTitle>
-    <VersionPrefix>2.0.2</VersionPrefix>
-    <Version>2.0.2</Version>
+    <VersionPrefix>2.0.3</VersionPrefix>
+    <Version>2.0.3</Version>
     <Authors>Payload, Ian Halpern, Ben Ward</Authors>
     <AssemblyName>Payload</AssemblyName>
     <PackageId>payload-api</PackageId>

--- a/src/Payload/Session.cs
+++ b/src/Payload/Session.cs
@@ -9,6 +9,7 @@ namespace Payload
     {
         public partial class Session
         {
+            public dynamic Attr = new Attr(null);
             public ARMRequest<pl.AccessToken> AccessToken => new ARMRequest<pl.AccessToken>(this);
             public ARMRequest<pl.ClientToken> ClientToken => new ARMRequest<pl.ClientToken>(this);
             public ARMRequest<pl.Account> Account => new ARMRequest<pl.Account>(this);

--- a/src/PayloadTests/DeepDiff.cs
+++ b/src/PayloadTests/DeepDiff.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using Payload;
 using Payload.ARM;
 using System;
@@ -130,7 +131,7 @@ namespace Payload.Tests
             obj2.Age = 30;
 
             var ex = Assert.Throws<AssertionException>(() => DeepDiff.Diff(obj1, obj2));
-            Assert.AreEqual("Property 'Age' mismatch. Expected: 25, Actual: 30", ex.Message);
+            ClassicAssert.AreEqual("Property 'Age' mismatch. Expected: 25, Actual: 30", ex.Message);
         }
 
         [Test]
@@ -144,7 +145,7 @@ namespace Payload.Tests
             obj2.Age = 30;
 
             var ex = Assert.Throws<AssertionException>(() => DeepDiff.Diff(obj1, obj2));
-            Assert.AreEqual("Property 'Age' exists in the second object but not in the first.", ex.Message);
+            ClassicAssert.AreEqual("Property 'Age' exists in the second object but not in the first.", ex.Message);
         }
 
         [Test]
@@ -163,7 +164,7 @@ namespace Payload.Tests
             obj2.Details = nested2;
 
             var ex = Assert.Throws<AssertionException>(() => DeepDiff.Diff(obj1, obj2));
-            Assert.AreEqual("Property 'City' mismatch. Expected: New York, Actual: Los Angeles", ex.Message);
+            ClassicAssert.AreEqual("Property 'City' mismatch. Expected: New York, Actual: Los Angeles", ex.Message);
         }
 
         [Test]
@@ -178,7 +179,7 @@ namespace Payload.Tests
             obj2.Numbers = new List<int> { 1, 2, 4 };
 
             var ex = Assert.Throws<AssertionException>(() => DeepDiff.Diff(obj1, obj2));
-            Assert.AreEqual("List item '[2]' mismatch. Expected: 3, Actual: 4", ex.Message);
+            ClassicAssert.AreEqual("List item '[2]' mismatch. Expected: 3, Actual: 4", ex.Message);
         }
 
         [Test]
@@ -197,7 +198,7 @@ namespace Payload.Tests
             obj2.DetailsList = new List<ExpandoObject> { nestedItem2 };
 
             var ex = Assert.Throws<AssertionException>(() => DeepDiff.Diff(obj1, obj2));
-            Assert.AreEqual("Property 'City' mismatch. Expected: New York, Actual: Los Angeles", ex.Message);
+            ClassicAssert.AreEqual("Property 'City' mismatch. Expected: New York, Actual: Los Angeles", ex.Message);
         }
 
         [Test]
@@ -252,7 +253,7 @@ namespace Payload.Tests
                             },
                         }
             }));
-            Assert.AreEqual("Property 'name' mismatch. Expected: Billy Bob, Actual: Billy Joe", ex.Message);
+            ClassicAssert.AreEqual("Property 'name' mismatch. Expected: Billy Bob, Actual: Billy Joe", ex.Message);
         }
     }
 }

--- a/src/PayloadTests/PayloadTests.csproj
+++ b/src/PayloadTests/PayloadTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,9 +11,9 @@
     <PackageReference Include="Moq" Version="4.20.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PayloadTests/TestARMRequest.cs
+++ b/src/PayloadTests/TestARMRequest.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using Payload.ARM;
 using System;
 using System.Collections.Generic;
@@ -23,8 +24,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?fields[0]=*&fields[1]=name", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?fields[0]=*&fields[1]=name", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -44,8 +45,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?offset=5&limit=10", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?offset=5&limit=10", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -64,8 +65,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?fields[0]=processing%5Bname%5D&fields[1]=sum(amount)", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?fields[0]=processing%5Bname%5D&fields[1]=sum(amount)", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -88,8 +89,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?name=Jimmy+John&payment_method[uses]=%3E%3D1&payment_method[card_number][expiry_date]=%3E2015-01-01&payment_method[card_number][expiry_date]=%3C2015-12-31&processing_id=acct_0a9s87df0987adsf", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?name=Jimmy+John&payment_method[uses]=%3E%3D1&payment_method[card_number][expiry_date]=%3E2015-01-01&payment_method[card_number][expiry_date]=%3C2015-12-31&processing_id=acct_0a9s87df0987adsf", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -118,8 +119,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?group_by[0]=name&group_by[1]=created_at", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?group_by[0]=name&group_by[1]=created_at", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -142,8 +143,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?order_by[0]=asc(name)&order_by[1]=desc(created_at)&order_by[2]=attrs%5Btest%5D", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?order_by[0]=asc(name)&order_by[1]=desc(created_at)&order_by[2]=attrs%5Btest%5D", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -167,8 +168,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers?limit=1", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers?limit=1", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -187,8 +188,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -207,8 +208,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.GET, method);
-                    Assert.AreEqual("/customers/test_id", route);
+                    ClassicAssert.AreEqual(RequestMethods.GET, method);
+                    ClassicAssert.AreEqual("/customers/test_id", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -227,8 +228,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), It.IsAny<ExpandoObject>()))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.POST, method);
-                    Assert.AreEqual("/customers", route);
+                    ClassicAssert.AreEqual(RequestMethods.POST, method);
+                    ClassicAssert.AreEqual("/customers", route);
                     DeepDiff.Diff(new { name = "Billy Bob", email = "billy.bob@payload.com" }, body);
                 })
                 .ReturnsAsync(mockRespJson);
@@ -252,8 +253,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), It.IsAny<ExpandoObject>()))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.POST, method);
-                    Assert.AreEqual("/customers", route);
+                    ClassicAssert.AreEqual(RequestMethods.POST, method);
+                    ClassicAssert.AreEqual("/customers", route);
                     DeepDiff.Diff(new
                     {
                         @object = "list",
@@ -311,8 +312,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), It.IsAny<ExpandoObject>()))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.PUT, method);
-                    Assert.AreEqual("/customers", route);
+                    ClassicAssert.AreEqual(RequestMethods.PUT, method);
+                    ClassicAssert.AreEqual("/customers", route);
                     DeepDiff.Diff(new
                     {
                         @object = "list",
@@ -365,8 +366,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), It.IsAny<ExpandoObject>()))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.PUT, method);
-                    Assert.AreEqual("/customers?processing_id=acct_9s8d7f98s7dfsf&mode=query", route);
+                    ClassicAssert.AreEqual(RequestMethods.PUT, method);
+                    ClassicAssert.AreEqual("/customers?processing_id=acct_9s8d7f98s7dfsf&mode=query", route);
                     DeepDiff.Diff(new { email = "matt.perez@newwork.com" }, body);
                 })
                 .ReturnsAsync(mockRespJson);
@@ -388,8 +389,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.DELETE, method);
-                    Assert.AreEqual("/customers/acct_s9d87f9s8d7f9", route);
+                    ClassicAssert.AreEqual(RequestMethods.DELETE, method);
+                    ClassicAssert.AreEqual("/customers/acct_s9d87f9s8d7f9", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -416,8 +417,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.DELETE, method);
-                    Assert.AreEqual("/customers?mode=query&id=acct_s9d87f9s8d7f9%7Cacct_987gs09d87f9d", route);
+                    ClassicAssert.AreEqual(RequestMethods.DELETE, method);
+                    ClassicAssert.AreEqual("/customers?mode=query&id=acct_s9d87f9s8d7f9%7Cacct_987gs09d87f9d", route);
                 })
                 .ReturnsAsync(mockRespJson);
 
@@ -450,8 +451,8 @@ namespace Payload.Tests
             mock.Setup(m => m.ExecuteRequestAsync(It.IsAny<RequestMethods>(), It.IsAny<string>(), null))
                 .Callback<RequestMethods, string, ExpandoObject>((method, route, body) =>
                 {
-                    Assert.AreEqual(RequestMethods.DELETE, method);
-                    Assert.AreEqual("/customers?processing_id=acct_9s8d7f98s7dfsf&mode=query", route);
+                    ClassicAssert.AreEqual(RequestMethods.DELETE, method);
+                    ClassicAssert.AreEqual("/customers?processing_id=acct_9s8d7f98s7dfsf&mode=query", route);
                 })
                 .ReturnsAsync(mockRespJson);
 

--- a/src/PayloadTests/TestAccessToken.cs
+++ b/src/PayloadTests/TestAccessToken.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.IO;
 using System.Text;
@@ -19,8 +20,8 @@ namespace Payload.Tests
         public void test_create_client_token()
         {
             dynamic client_token = pl.ClientToken.Create();
-            Assert.AreEqual(client_token.status, "active");
-            Assert.AreEqual(client_token.type, "client");
+            ClassicAssert.AreEqual(client_token.status, "active");
+            ClassicAssert.AreEqual(client_token.type, "client");
 
         }
 

--- a/src/PayloadTests/TestAccount.cs
+++ b/src/PayloadTests/TestAccount.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 
 namespace Payload.Tests
@@ -20,30 +21,30 @@ namespace Payload.Tests
         [Test]
         public void test_create_customer_account()
         {
-            Assert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
-            Assert.AreEqual("Customer Account", this.customer_account.name);
-            Assert.NotNull(this.customer_account.id);
+            ClassicAssert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
+            ClassicAssert.AreEqual("Customer Account", this.customer_account.name);
+            ClassicAssert.NotNull(this.customer_account.id);
         }
 
 
         public void test_create_processing_account()
         {
-            Assert.AreEqual(typeof(pl.ProcessingAccount), this.processing_account.GetType());
-            Assert.NotNull(this.processing_account.id);
+            ClassicAssert.AreEqual(typeof(pl.ProcessingAccount), this.processing_account.GetType());
+            ClassicAssert.NotNull(this.processing_account.id);
         }
 
         [Test]
         public void test_customer_account_one()
         {
-            Assert.NotNull(pl.Customer.FilterBy(new { email = customer_account.email }).One());
-            Assert.AreEqual(typeof(pl.Customer), pl.Customer.FilterBy(new { email = customer_account.email }).One().GetType());
+            ClassicAssert.NotNull(pl.Customer.FilterBy(new { email = customer_account.email }).One());
+            ClassicAssert.AreEqual(typeof(pl.Customer), pl.Customer.FilterBy(new { email = customer_account.email }).One().GetType());
         }
 
         [Test]
         public void test_processing_account_one()
         {
-            Assert.NotNull(pl.ProcessingAccount.FilterBy(new { name = processing_account.name }).One());
-            Assert.AreEqual(typeof(pl.ProcessingAccount), pl.ProcessingAccount.FilterBy(new { name = processing_account.name }).One().GetType());
+            ClassicAssert.NotNull(pl.ProcessingAccount.FilterBy(new { name = processing_account.name }).One());
+            ClassicAssert.AreEqual(typeof(pl.ProcessingAccount), pl.ProcessingAccount.FilterBy(new { name = processing_account.name }).One().GetType());
         }
 
         [Test]
@@ -71,15 +72,15 @@ namespace Payload.Tests
             var get_account_1 = pl.Account.FilterBy(new { email = rand_email1 }).All()[0];
             var get_account_2 = pl.Account.FilterBy(new { email = rand_email2 }).All()[0];
 
-            Assert.NotNull(get_account_1);
-            Assert.NotNull(get_account_2);
+            ClassicAssert.NotNull(get_account_1);
+            ClassicAssert.NotNull(get_account_2);
 
         }
         [Test]
         public void test_get_processing_account()
         {
-            Assert.AreEqual(typeof(pl.ProcessingAccount), this.processing_account.GetType());
-            Assert.NotNull(pl.ProcessingAccount.Get(this.processing_account.id));
+            ClassicAssert.AreEqual(typeof(pl.ProcessingAccount), this.processing_account.GetType());
+            ClassicAssert.NotNull(pl.ProcessingAccount.Get(this.processing_account.id));
         }
 
 
@@ -94,9 +95,9 @@ namespace Payload.Tests
 
             dynamic customers = pl.Customer.FilterBy(new { order_by = "created_at", limit = 3, offset = 1 }).All();
 
-            Assert.True(customers.Count == 3);
-            Assert.True(Convert.ToDateTime(customers[0].created_at) <= Convert.ToDateTime(customers[1].created_at));
-            Assert.True(Convert.ToDateTime(customers[1].created_at) <= Convert.ToDateTime(customers[2].created_at));
+            ClassicAssert.True(customers.Count == 3);
+            ClassicAssert.True(Convert.ToDateTime(customers[0].created_at) <= Convert.ToDateTime(customers[1].created_at));
+            ClassicAssert.True(Convert.ToDateTime(customers[1].created_at) <= Convert.ToDateTime(customers[2].created_at));
 
 
         }
@@ -108,7 +109,7 @@ namespace Payload.Tests
         {
             this.customer_account.Update(new { email = "test2@example.com" });
 
-            Assert.True(this.customer_account.email == "test2@example.com");
+            ClassicAssert.True(this.customer_account.email == "test2@example.com");
         }
 
 
@@ -131,15 +132,15 @@ namespace Payload.Tests
                 (customer_account_2, new { email = "andrea.kearney@newwork.com" })
             );
 
-            Assert.True(customer_account_1.Data.email == "brandy@example.com");
-            Assert.True(customer_account_2.Data.email == "sandy@example.com");
+            ClassicAssert.True(customer_account_1.Data.email == "brandy@example.com");
+            ClassicAssert.True(customer_account_2.Data.email == "sandy@example.com");
         }
 
         [Test]
         public void test_get_customer_account()
         {
-            Assert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
-            Assert.NotNull(pl.Customer.Get(this.customer_account.id));
+            ClassicAssert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
+            ClassicAssert.NotNull(pl.Customer.Get(this.customer_account.id));
         }
 
 
@@ -149,8 +150,8 @@ namespace Payload.Tests
         {
             var select_customer = pl.Customer.Select("id").Get(this.customer_account.id);
 
-            Assert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
-            Assert.True(select_customer.id == this.customer_account.id);
+            ClassicAssert.AreEqual(typeof(pl.Customer), this.customer_account.GetType());
+            ClassicAssert.True(select_customer.id == this.customer_account.id);
         }
 
     }

--- a/src/PayloadTests/TestAttr.cs
+++ b/src/PayloadTests/TestAttr.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using Payload.ARM;
 using System;
 using System.Collections.Generic;
@@ -28,7 +29,7 @@ namespace Payload.Tests
             var result = actual.ToString();
 
             // Assert
-            Assert.AreEqual("payment_method[card_number]", result);
+            ClassicAssert.AreEqual("payment_method[card_number]", result);
         }
 
         [Test]
@@ -41,7 +42,7 @@ namespace Payload.Tests
             var result = actual.ToString();
 
             // Assert
-            Assert.AreEqual("sum(amount)", result);
+            ClassicAssert.AreEqual("sum(amount)", result);
         }
 
         [Test]
@@ -54,7 +55,7 @@ namespace Payload.Tests
             var result = actual.ToString();
 
             // Assert
-            Assert.AreEqual("payment_method[card_number][expiry_date]", result);
+            ClassicAssert.AreEqual("payment_method[card_number][expiry_date]", result);
         }
     }
 }

--- a/src/PayloadTests/TestBilling.cs
+++ b/src/PayloadTests/TestBilling.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 
 namespace Payload.Tests
@@ -31,20 +32,20 @@ namespace Payload.Tests
         [Test]
         public void test_create_billing_schedule()
         {
-            Assert.AreEqual(typeof(pl.BillingSchedule), this.billing_schedule.GetType());
-            Assert.True(this.billing_schedule.processing_id == this.processing_account.id);
-            Assert.True(this.billing_schedule.charges[0].amount == 39.99);
+            ClassicAssert.AreEqual(typeof(pl.BillingSchedule), this.billing_schedule.GetType());
+            ClassicAssert.True(this.billing_schedule.processing_id == this.processing_account.id);
+            ClassicAssert.True(this.billing_schedule.charges[0].amount == 39.99);
         }
 
         [Test]
         public void test_update_billing_schedule_frequency()
         {
-            Assert.True(this.billing_schedule.processing_id == processing_account.id);
-            Assert.True(this.billing_schedule.charges[0].amount == 39.99);
+            ClassicAssert.True(this.billing_schedule.processing_id == processing_account.id);
+            ClassicAssert.True(this.billing_schedule.charges[0].amount == 39.99);
 
             this.billing_schedule.Update(new { recurring_frequency = "quarterly" });
 
-            Assert.True(this.billing_schedule.recurring_frequency == "quarterly");
+            ClassicAssert.True(this.billing_schedule.recurring_frequency == "quarterly");
         }
 
 
@@ -53,23 +54,23 @@ namespace Payload.Tests
         {
             var billing_charge = pl.BillingSchedule.Select("*", "charges").Get(this.billing_schedule.id).charges[0];
 
-            Assert.AreEqual(typeof(pl.BillingCharge), billing_charge.GetType());
+            ClassicAssert.AreEqual(typeof(pl.BillingCharge), billing_charge.GetType());
         }
 
 
         [Test]
         public void test_billing_schedule_one()
         {
-            Assert.NotNull(pl.BillingSchedule.FilterBy(new { type = this.billing_schedule.type }).One());
-            Assert.AreEqual(typeof(pl.BillingSchedule), pl.BillingSchedule.FilterBy(new { type = billing_schedule.type }).One().GetType());
+            ClassicAssert.NotNull(pl.BillingSchedule.FilterBy(new { type = this.billing_schedule.type }).One());
+            ClassicAssert.AreEqual(typeof(pl.BillingSchedule), pl.BillingSchedule.FilterBy(new { type = billing_schedule.type }).One().GetType());
         }
 
         [Test]
         public void test_billing_charge_one()
         {
-            Assert.NotNull(pl.BillingCharge.FilterBy(new { type = this.billing_schedule.charges[0].type }).One());
+            ClassicAssert.NotNull(pl.BillingCharge.FilterBy(new { type = this.billing_schedule.charges[0].type }).One());
 
-            Assert.AreEqual(typeof(pl.BillingCharge), pl.BillingCharge.FilterBy(new { type = this.billing_schedule.charges[0].type }).One().GetType());
+            ClassicAssert.AreEqual(typeof(pl.BillingCharge), pl.BillingCharge.FilterBy(new { type = this.billing_schedule.charges[0].type }).One().GetType());
         }
     }
 }

--- a/src/PayloadTests/TestInvoice.cs
+++ b/src/PayloadTests/TestInvoice.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 
 namespace Payload.Tests
@@ -32,9 +33,9 @@ namespace Payload.Tests
         [Test]
         public void test_create_invoice()
         {
-            Assert.AreEqual(typeof(pl.Invoice), this.invoice.GetType());
-            Assert.True(this.invoice.due_date == "2019-05-01");
-            Assert.True(this.invoice.status == "unpaid");
+            ClassicAssert.AreEqual(typeof(pl.Invoice), this.invoice.GetType());
+            ClassicAssert.True(this.invoice.due_date == "2019-05-01");
+            ClassicAssert.True(this.invoice.status == "unpaid");
         }
 
         [Test]
@@ -65,8 +66,8 @@ namespace Payload.Tests
                 customer_id = cust.id
             });
 
-            Assert.AreEqual(typeof(pl.Invoice), invoice.GetType());
-            Assert.AreEqual(cust.id, invoice.customer_id);
+            ClassicAssert.AreEqual(typeof(pl.Invoice), invoice.GetType());
+            ClassicAssert.AreEqual(cust.id, invoice.customer_id);
 
             if (invoice.status != "paid")
             {
@@ -83,7 +84,7 @@ namespace Payload.Tests
 
                 var invoice_get = pl.Invoice.Get(invoice.id);
 
-                Assert.AreEqual("paid", invoice_get.status);
+                ClassicAssert.AreEqual("paid", invoice_get.status);
 
             }
         }
@@ -91,8 +92,8 @@ namespace Payload.Tests
         [Test]
         public void test_invoice_one()
         {
-            Assert.NotNull(pl.Invoice.FilterBy(new { this.invoice.type }).One());
-            Assert.AreEqual(typeof(pl.Invoice), pl.Invoice.FilterBy(new { this.invoice.type }).One().GetType());
+            ClassicAssert.NotNull(pl.Invoice.FilterBy(new { this.invoice.type }).One());
+            ClassicAssert.AreEqual(typeof(pl.Invoice), pl.Invoice.FilterBy(new { this.invoice.type }).One().GetType());
         }
     }
 }

--- a/src/PayloadTests/TestPaymentLink.cs
+++ b/src/PayloadTests/TestPaymentLink.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.IO;
 using System.Text;
@@ -29,15 +30,15 @@ namespace Payload.Tests
         [Test]
         public void test_create_payment_link()
         {
-            Assert.True(payment_link.processing_id == this.processing_account.id);
+            ClassicAssert.True(payment_link.processing_id == this.processing_account.id);
         }
 
         [Test]
         public void test_payment_link_one()
         {
             var lnk = pl.PaymentLink.FilterBy(new { type = this.payment_link.type }).One();
-            Assert.NotNull(lnk);
-            Assert.AreEqual(typeof(pl.PaymentLink), lnk.GetType());
+            ClassicAssert.NotNull(lnk);
+            ClassicAssert.AreEqual(typeof(pl.PaymentLink), lnk.GetType());
         }
 
 
@@ -78,9 +79,9 @@ namespace Payload.Tests
                     },
                     attachments = new[] { new { file = fs } }
                 });
-                Assert.True(lnk.processing_id == this.processing_account.id);
-                Assert.True(lnk.attachments.Count == 1);
-                Assert.False(lnk.checkout_options.billing_address);
+                ClassicAssert.True(lnk.processing_id == this.processing_account.id);
+                ClassicAssert.True(lnk.attachments.Count == 1);
+                ClassicAssert.False(lnk.checkout_options.billing_address);
 
                 HttpWebRequest request = (HttpWebRequest)WebRequest.Create(lnk.attachments[0].url);
 
@@ -92,7 +93,7 @@ namespace Payload.Tests
                     content = reader.ReadToEnd();
                 }
 
-                Assert.True(content.Equals("This is some text in the file."));
+                ClassicAssert.True(content.Equals("This is some text in the file."));
             }
         }
 

--- a/src/PayloadTests/TestPaymentMethod.cs
+++ b/src/PayloadTests/TestPaymentMethod.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 
 
 namespace Payload.Tests
@@ -36,15 +37,15 @@ namespace Payload.Tests
         [Test]
         public void test_create_payment_method_card()
         {
-            Assert.AreEqual(typeof(pl.Card), this.card_payment_method.GetType());
-            Assert.AreEqual("xxxxxxxxxxxx4242", this.card_payment_method.card_number);
+            ClassicAssert.AreEqual(typeof(pl.Card), this.card_payment_method.GetType());
+            ClassicAssert.AreEqual("xxxxxxxxxxxx4242", this.card_payment_method.card_number);
         }
 
         [Test]
         public void test_create_payment_method_bank()
         {
-            Assert.AreEqual(typeof(pl.BankAccount), this.bank_payment_method.GetType());
-            Assert.AreEqual("checking", this.bank_payment_method.account_type);
+            ClassicAssert.AreEqual(typeof(pl.BankAccount), this.bank_payment_method.GetType());
+            ClassicAssert.AreEqual("checking", this.bank_payment_method.account_type);
 
         }
 
@@ -59,14 +60,14 @@ namespace Payload.Tests
         [Test]
         public void test_card_payment_method_one()
         {
-            Assert.NotNull(pl.PaymentMethod.FilterBy(new { this.card_payment_method.type }).One());
+            ClassicAssert.NotNull(pl.PaymentMethod.FilterBy(new { this.card_payment_method.type }).One());
 
         }
 
         [Test]
         public void test_bank_payment_method_one()
         {
-            Assert.NotNull(pl.PaymentMethod.FilterBy(new { this.bank_payment_method.type }).One());
+            ClassicAssert.NotNull(pl.PaymentMethod.FilterBy(new { this.bank_payment_method.type }).One());
         }
     }
 }

--- a/src/PayloadTests/TestSession.cs
+++ b/src/PayloadTests/TestSession.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using Payload.ARM;
 using System;
 using System.Collections.Generic;
@@ -22,6 +23,20 @@ namespace Payload.Tests
             string url = Environment.GetEnvironmentVariable("API_URL");
             if (url != null)
                 this.session.ApiUrl = url;
+        }
+
+        [Test]
+        public void TestAttrToStringProperty()
+        {
+            // Arrange
+            var pl = this.session
+            var actual = pl.Attr.payment_method.card_number;
+
+            // Act
+            var result = actual.ToString();
+
+            // Assert
+            ClassicAssert.AreEqual("payment_method[card_number]", result);
         }
 
         [Test]
@@ -70,12 +85,12 @@ namespace Payload.Tests
         public void test_client_token()
         {
             dynamic client_token = this.session.ClientToken.Create();
-            Assert.AreEqual(client_token.status, "active");
-            Assert.AreEqual(client_token.type, "client");
+            ClassicAssert.AreEqual(client_token.status, "active");
+            ClassicAssert.AreEqual(client_token.type, "client");
 
             client_token = this.session.ClientToken.Create(new { });
-            Assert.AreEqual(client_token.status, "active");
-            Assert.AreEqual(client_token.type, "client");
+            ClassicAssert.AreEqual(client_token.status, "active");
+            ClassicAssert.AreEqual(client_token.type, "client");
         }
 
         [Test]
@@ -88,7 +103,7 @@ namespace Payload.Tests
             );
 
             var get_account = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).One();
-            Assert.NotNull(get_account);
+            ClassicAssert.NotNull(get_account);
         }
 
         [Test]
@@ -105,8 +120,8 @@ namespace Payload.Tests
             var get_account_1 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).One();
             var get_account_2 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).One();
 
-            Assert.NotNull(get_account_1);
-            Assert.NotNull(get_account_2);
+            ClassicAssert.NotNull(get_account_1);
+            ClassicAssert.NotNull(get_account_2);
         }
 
         [Test]
@@ -120,8 +135,8 @@ namespace Payload.Tests
             );
 
             dynamic get_account = this.session.Select<pl.Customer>().Get(account.id);
-            Assert.NotNull(get_account);
-            Assert.True(account.id == get_account.id);
+            ClassicAssert.NotNull(get_account);
+            ClassicAssert.True(account.id == get_account.id);
         }
 
         [Test]
@@ -136,8 +151,8 @@ namespace Payload.Tests
 
             var get_account1 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).One();
             var get_account2 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).One();
-            Assert.NotNull(get_account1);
-            Assert.Null(get_account2);
+            ClassicAssert.NotNull(get_account1);
+            ClassicAssert.Null(get_account2);
 
             account.Update(new
             {
@@ -146,8 +161,8 @@ namespace Payload.Tests
 
             get_account1 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).One();
             get_account2 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).One();
-            Assert.Null(get_account1);
-            Assert.NotNull(get_account2);
+            ClassicAssert.Null(get_account1);
+            ClassicAssert.NotNull(get_account2);
 
         }
 
@@ -161,12 +176,12 @@ namespace Payload.Tests
             );
 
             var get_account = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).One();
-            Assert.NotNull(get_account);
+            ClassicAssert.NotNull(get_account);
 
             this.session.Delete(account);
 
             get_account = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).One();
-            Assert.Null(get_account);
+            ClassicAssert.Null(get_account);
         }
 
         [Test]
@@ -186,16 +201,16 @@ namespace Payload.Tests
             var get_account_1 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).One();
             var get_account_2 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).One();
 
-            Assert.NotNull(get_account_1);
-            Assert.NotNull(get_account_2);
+            ClassicAssert.NotNull(get_account_1);
+            ClassicAssert.NotNull(get_account_2);
 
             this.session.DeleteAll(accounts);
 
             get_account_1 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).One();
             get_account_2 = this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).One();
 
-            Assert.Null(get_account_1);
-            Assert.Null(get_account_2);
+            ClassicAssert.Null(get_account_1);
+            ClassicAssert.Null(get_account_2);
         }
 
         [Test]
@@ -208,7 +223,7 @@ namespace Payload.Tests
             );
 
             var get_account = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).OneAsync();
-            Assert.NotNull(get_account);
+            ClassicAssert.NotNull(get_account);
         }
 
         [Test]
@@ -225,8 +240,8 @@ namespace Payload.Tests
             var get_account_1 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).OneAsync();
             var get_account_2 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).OneAsync();
 
-            Assert.NotNull(get_account_1);
-            Assert.NotNull(get_account_2);
+            ClassicAssert.NotNull(get_account_1);
+            ClassicAssert.NotNull(get_account_2);
         }
 
         [Test]
@@ -240,8 +255,8 @@ namespace Payload.Tests
            );
 
             var get_account = await this.session.Select<pl.Customer>().GetAsync(account.Data.id);
-            Assert.NotNull(get_account);
-            Assert.True(account.Data.id == get_account.id);
+            ClassicAssert.NotNull(get_account);
+            ClassicAssert.True(account.Data.id == get_account.id);
         }
 
         [Test]
@@ -256,8 +271,8 @@ namespace Payload.Tests
 
             var get_account1 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).OneAsync();
             var get_account2 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).OneAsync();
-            Assert.NotNull(get_account1);
-            Assert.Null(get_account2);
+            ClassicAssert.NotNull(get_account1);
+            ClassicAssert.Null(get_account2);
 
             await account.UpdateAsync(new
             {
@@ -266,8 +281,8 @@ namespace Payload.Tests
 
             get_account1 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).OneAsync();
             get_account2 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).OneAsync();
-            Assert.Null(get_account1);
-            Assert.NotNull(get_account2);
+            ClassicAssert.Null(get_account1);
+            ClassicAssert.NotNull(get_account2);
 
         }
 
@@ -281,12 +296,12 @@ namespace Payload.Tests
             );
 
             var get_account = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).OneAsync();
-            Assert.NotNull(get_account);
+            ClassicAssert.NotNull(get_account);
 
             await this.session.DeleteAsync(account);
 
             get_account = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email }).OneAsync();
-            Assert.Null(get_account);
+            ClassicAssert.Null(get_account);
         }
 
         [Test]
@@ -306,16 +321,16 @@ namespace Payload.Tests
             var get_account_1 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).OneAsync();
             var get_account_2 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).OneAsync();
 
-            Assert.NotNull(get_account_1);
-            Assert.NotNull(get_account_2);
+            ClassicAssert.NotNull(get_account_1);
+            ClassicAssert.NotNull(get_account_2);
 
             await this.session.DeleteAllAsync(accounts);
 
             get_account_1 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email1 }).OneAsync();
             get_account_2 = await this.session.Select<pl.Customer>().FilterBy(new { email = rand_email2 }).OneAsync();
 
-            Assert.Null(get_account_1);
-            Assert.Null(get_account_2);
+            ClassicAssert.Null(get_account_1);
+            ClassicAssert.Null(get_account_2);
         }
     }
 }

--- a/src/PayloadTests/TestSession.cs
+++ b/src/PayloadTests/TestSession.cs
@@ -29,7 +29,7 @@ namespace Payload.Tests
         public void TestAttrToStringProperty()
         {
             // Arrange
-            var pl = this.session
+            var pl = this.session;
             var actual = pl.Attr.payment_method.card_number;
 
             // Act

--- a/src/PayloadTests/TestTransaction.cs
+++ b/src/PayloadTests/TestTransaction.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using NUnit.Framework.Legacy;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace Payload.Tests
 
             dynamic transaction = pl.Transaction.Select("*", "ledger").Get(this.card_payment.id);
 
-            Assert.IsEmpty(transaction.ledger);
+            ClassicAssert.IsEmpty(transaction.ledger);
         }
 
         [Test]
@@ -36,7 +37,7 @@ namespace Payload.Tests
 
             var transaction = pl.Transaction.Get(card_payment.id);
 
-            Assert.True(transaction.id == card_payment.id);
+            ClassicAssert.True(transaction.id == card_payment.id);
         }
 
         [Test]
@@ -44,8 +45,8 @@ namespace Payload.Tests
         {
             this.card_payment = Fixtures.card_payment();
 
-            Assert.NotNull(pl.Transaction.FilterBy(new { type = this.card_payment.type }).One());
-            Assert.AreEqual(typeof(pl.Payment), pl.Payment.FilterBy(new { amount = this.card_payment.amount }).One().GetType());
+            ClassicAssert.NotNull(pl.Transaction.FilterBy(new { type = this.card_payment.type }).One());
+            ClassicAssert.AreEqual(typeof(pl.Payment), pl.Payment.FilterBy(new { amount = this.card_payment.amount }).One().GetType());
         }
 
         [Test]
@@ -53,7 +54,7 @@ namespace Payload.Tests
         {
             this.card_payment = Fixtures.card_payment();
 
-            Assert.True(this.card_payment.risk_flag == "allowed");
+            ClassicAssert.True(this.card_payment.risk_flag == "allowed");
         }
 
         [Test]
@@ -62,7 +63,7 @@ namespace Payload.Tests
             this.card_payment = Fixtures.card_payment();
 
             this.card_payment.Update(new { status = "voided" });
-            Assert.True(card_payment.status == "voided");
+            ClassicAssert.True(card_payment.status == "voided");
 
         }
 
@@ -95,8 +96,8 @@ namespace Payload.Tests
                 pl.Attr.created_at.gt(new DateTime(2019, 2, 1))
             }).All();
 
-            Assert.True(payments.Count == 1);
-            Assert.True(payments.ElementAt(0).Data.id == card_payment.id);
+            ClassicAssert.True(payments.Count == 1);
+            ClassicAssert.True(payments.ElementAt(0).Data.id == card_payment.id);
         }
 
         [Test]
@@ -106,7 +107,7 @@ namespace Payload.Tests
 
             ((pl.Payment)this.card_payment).Update(new { status = "voided" });
 
-            Assert.AreEqual("voided", this.card_payment.status);
+            ClassicAssert.AreEqual("voided", this.card_payment.status);
         }
 
         [Test]
@@ -115,7 +116,7 @@ namespace Payload.Tests
             this.bank_payment = Fixtures.bank_payment();
 
             ((pl.Payment)this.bank_payment).Update(new { status = "voided" });
-            Assert.AreEqual("voided", this.bank_payment.status);
+            ClassicAssert.AreEqual("voided", this.bank_payment.status);
 
         }
 
@@ -134,9 +135,9 @@ namespace Payload.Tests
                 }
             });
 
-            Assert.True(refund.type == "refund");
-            Assert.True(refund.amount == this.card_payment.amount);
-            Assert.True(refund.status_code == "approved");
+            ClassicAssert.True(refund.type == "refund");
+            ClassicAssert.True(refund.amount == this.card_payment.amount);
+            ClassicAssert.True(refund.status_code == "approved");
         }
 
         [Test]
@@ -154,9 +155,9 @@ namespace Payload.Tests
                 }
             });
 
-            Assert.True(refund.type == "refund");
-            Assert.True(refund.amount == 10);
-            Assert.True(refund.status_code == "approved");
+            ClassicAssert.True(refund.type == "refund");
+            ClassicAssert.True(refund.amount == 10);
+            ClassicAssert.True(refund.status_code == "approved");
         }
 
         [Test]
@@ -169,9 +170,9 @@ namespace Payload.Tests
                 payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
             });
 
-            Assert.True(refund.type == "refund");
-            Assert.True(refund.amount == 10);
-            Assert.True(refund.status_code == "approved");
+            ClassicAssert.True(refund.type == "refund");
+            ClassicAssert.True(refund.amount == 10);
+            ClassicAssert.True(refund.status_code == "approved");
 
         }
 
@@ -190,9 +191,9 @@ namespace Payload.Tests
                 }
             });
 
-            Assert.True(refund.type == "refund");
-            Assert.True(refund.amount == this.bank_payment.amount);
-            Assert.True(refund.status_code == "approved");
+            ClassicAssert.True(refund.type == "refund");
+            ClassicAssert.True(refund.amount == this.bank_payment.amount);
+            ClassicAssert.True(refund.status_code == "approved");
         }
 
         [Test]
@@ -210,9 +211,9 @@ namespace Payload.Tests
                 }
             });
 
-            Assert.True(refund.type == "refund");
-            Assert.True(refund.amount == 10);
-            Assert.True(refund.status_code == "approved");
+            ClassicAssert.True(refund.type == "refund");
+            ClassicAssert.True(refund.amount == 10);
+            ClassicAssert.True(refund.status_code == "approved");
         }
 
 
@@ -225,8 +226,8 @@ namespace Payload.Tests
                 payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
             });
 
-            Assert.NotNull(payment.fee);
-            Assert.NotNull(payment.conv_fee);
+            ClassicAssert.NotNull(payment.fee);
+            ClassicAssert.NotNull(payment.conv_fee);
         }
     }
 }


### PR DESCRIPTION
# Added `Attr` field selector to `Payload.Session` class

If you're using `Payload.Session` to manage API authentication sessions,
you can access the magic `Attr` selector from the `Session` instance.
This matches the legacy method of using the `Payload.pl` object.
Here's an example of how this can be used: 

```
var pl = new Payload.Session("your_secret_key");

dynamic payments = await pl.Payment
    .FilterBy(
        pl.Attr.modified_at.gt(new DateTime(2024,5,1))
    )
    .AllAsync();
```

Changes include:

- [x] Added `Attr` field selector to `Payload.Session` class
- [x] Updated `nunit` dependencies and migrated to `ClassicAssert`

## Type of change

- Bug fix (non-breaking change which fixes an issue)