### PR TITLE
Enhancement/upgrade api v2

### DIFF
--- a/src/Payload/ARM/ARMRequest.cs
+++ b/src/Payload/ARM/ARMRequest.cs
@@ -28,7 +28,7 @@ namespace Payload.ARM
         public List<string> _fields;
         public List<string> _group_by;
         public List<string> _order_by;
-        private Payload.Session session;        
+        private Payload.Session session;
         internal HttpMessageHandler _httpMessageHandler;
         private static JsonSerializerSettings jsonsettings = new JsonSerializerSettings
         {

--- a/src/Payload/ARM/ARMRequest.cs
+++ b/src/Payload/ARM/ARMRequest.cs
@@ -28,8 +28,8 @@ namespace Payload.ARM
         public List<string> _fields;
         public List<string> _group_by;
         public List<string> _order_by;
-        private Payload.Session session;
-
+        private Payload.Session session;        
+        internal HttpMessageHandler _httpMessageHandler;
         private static JsonSerializerSettings jsonsettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore
@@ -95,7 +95,11 @@ namespace Payload.ARM
 
         public virtual async Task<JSONObject> ExecuteRequestAsync(RequestMethods method, string route, ExpandoObject body = null)
         {
-            using (var http = new HttpClient())
+            var http = _httpMessageHandler != null 
+                ? new HttpClient(_httpMessageHandler, false)
+                : new HttpClient();
+                
+            using (http)
             {
                 string _auth = string.Concat(session.ApiKey, ":");
                 string _enc = Convert.ToBase64String(Encoding.ASCII.GetBytes(_auth));
@@ -104,6 +108,11 @@ namespace Payload.ARM
                     new AuthenticationHeaderValue("Basic", _enc);
                 http.DefaultRequestHeaders.Accept.Add(
                    new MediaTypeWithQualityHeaderValue("application/json"));
+
+                if (!string.IsNullOrEmpty(session.ApiVersion))
+                {
+                    http.DefaultRequestHeaders.Add("X-API-Version", session.ApiVersion);
+                }
 
                 HttpContent content;
                 if (body != null)

--- a/src/Payload/Exception.cs
+++ b/src/Payload/Exception.cs
@@ -23,7 +23,7 @@ namespace Payload
         public PayloadError(string message, JSONObject response) : base(message)
         {
             Response = response;
-            Details = Response["details"];
+            Details = Response.HasObject("details") ? Response["details"] : null;
         }
 
         public string json()

--- a/src/Payload/Payload.cs
+++ b/src/Payload/Payload.cs
@@ -4,6 +4,9 @@ using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using Payload.ARM;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PayloadTests")]
 
 namespace Payload
 {
@@ -16,17 +19,20 @@ namespace Payload
             private string _url = URL;
             public string ApiKey { get; set; }
             public string ApiUrl { get { return _url; } set { _url = value; } }
+            public string ApiVersion { get; set; }
 
-            public Session(string api_key)
+            public Session(string api_key, string api_version = null)
             {
                 ApiKey = api_key;
+                ApiVersion = api_version;
             }
 
             public override bool Equals(object obj)
             {
                 return obj is Session session &&
                         ApiKey == session.ApiKey &&
-                        ApiUrl == session.ApiUrl;
+                        ApiUrl == session.ApiUrl &&
+                        ApiVersion == session.ApiVersion;
             }
 
             public async Task<List<T>> CreateAllAsync<T>(params T[] objects) where T : ARMObjectBase<T>
@@ -98,6 +104,7 @@ namespace Payload
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(_url);
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ApiKey);
                 hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ApiUrl);
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ApiVersion);
                 return hashCode;
             }
         }
@@ -108,6 +115,8 @@ namespace Payload
 
         public static string ApiKey { get { return DefaultSession.ApiKey; } set { DefaultSession.ApiKey = value; } }
         public static string ApiUrl { get { return DefaultSession.ApiUrl; } set { DefaultSession.ApiUrl = value; } }
+        public static string ApiVersion { get { return DefaultSession.ApiVersion; } set { DefaultSession.ApiVersion = value; } }
+        
         public static dynamic Attr = new Attr(null);
         public static Payload.Session DefaultSession = new Payload.Session(null);
 
@@ -230,7 +239,8 @@ namespace Payload
         {
             public override ARMObjectSpec GetSpec() => new ARMObjectSpec
             {
-                Object = "org"
+                Object = "org",
+                Endpoint = "/accounts/orgs"
             };
             public Org(object obj) : base(obj) { }
             public Org() : base() { }
@@ -250,7 +260,8 @@ namespace Payload
         {
             public override ARMObjectSpec GetSpec() => new ARMObjectSpec
             {
-                Object = "transaction"
+                Object = "transaction",
+                Endpoint = "/transactions"
             };
             public Transaction(object obj) : base(obj) { }
             public Transaction() : base() { }
@@ -579,6 +590,163 @@ namespace Payload
             public PaymentActivation(object obj) : base(obj) { }
             public PaymentActivation() : base() { }
         }
+
+        public class Operation : ARMObjectBase<Operation>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "operation",
+
+            };
+            public Operation(object obj) : base(obj) { }
+            public Operation() : base() { }
+        }
+
+
+        // ============================================
+        // API V2 Objects
+        // ============================================
+        public class Profile : ARMObjectBase<Profile>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "profile"
+            };
+            public Profile(object obj) : base(obj) { }
+            public Profile() : base() { }
+        }
+
+        public class BillingItem : ARMObjectBase<BillingItem>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "billing_item"
+            };
+            public BillingItem(object obj) : base(obj) { }
+            public BillingItem() : base() { }
+        }
+
+        public class Intent : ARMObjectBase<Intent>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "intent"
+            };
+            public Intent(object obj) : base(obj) { }
+            public Intent() : base() { }
+        }
+
+        public class InvoiceItem : ARMObjectBase<InvoiceItem>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "invoice_item"
+            };
+            public InvoiceItem(object obj) : base(obj) { }
+            public InvoiceItem() : base() { }
+        }
+
+        public class PaymentAllocation : ARMObjectBase<PaymentAllocation>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "payment_allocation"
+            };
+            public PaymentAllocation(object obj) : base(obj) { }
+            public PaymentAllocation() : base() { }
+        }
+
+        public class Entity : ARMObjectBase<Entity>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "entity",
+                Endpoint = "/entities"
+            };
+            public Entity(object obj) : base(obj) { }
+            public Entity() : base() { }
+        }
+
+        public class Stakeholder : ARMObjectBase<Stakeholder>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "stakeholder"
+            };
+            public Stakeholder(object obj) : base(obj) { }
+            public Stakeholder() : base() { }
+        }
+
+        public class ProcessingAgreement : ARMObjectBase<ProcessingAgreement>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "processing_agreement"
+            };
+            public ProcessingAgreement(object obj) : base(obj) { }
+            public ProcessingAgreement() : base() { }
+        }
+
+        public class Transfer : ARMObjectBase<Transfer>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "transfer"
+            };
+            public Transfer(object obj) : base(obj) { }
+            public Transfer() : base() { }
+        }
+
+        public class TransactionOperation : ARMObjectBase<TransactionOperation>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "transaction_operation"
+            };
+            public TransactionOperation(object obj) : base(obj) { }
+            public TransactionOperation() : base() { }
+        }
+
+        public class CheckFront : ARMObjectBase<CheckFront>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "check_front"
+            };
+            public CheckFront(object obj) : base(obj) { }
+            public CheckFront() : base() { }
+        }
+
+        public class CheckBack : ARMObjectBase<CheckBack>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "check_back"
+            };
+            public CheckBack(object obj) : base(obj) { }
+            public CheckBack() : base() { }
+        }
+
+        public class ProcessingRule : ARMObjectBase<ProcessingRule>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "processing_rule"
+            };
+            public ProcessingRule(object obj) : base(obj) { }
+            public ProcessingRule() : base() { }
+        }
+
+        public class ProcessingSettings : ARMObjectBase<ProcessingSettings>
+        {
+            public override ARMObjectSpec GetSpec() => new ARMObjectSpec
+            {
+                Object = "processing_settings"
+            };
+            public ProcessingSettings(object obj) : base(obj) { }
+            public ProcessingSettings() : base() { }
+        }
+
 
         public class UnknownResponse : PayloadError
         {

--- a/src/Payload/Session.cs
+++ b/src/Payload/Session.cs
@@ -36,6 +36,21 @@ namespace Payload
             public ARMRequest<pl.PaymentLink> PaymentLink => new ARMRequest<pl.PaymentLink>(this);
             public ARMRequest<pl.OAuthToken> OAuthToken => new ARMRequest<pl.OAuthToken>(this);
             public ARMRequest<pl.PaymentActivation> PaymentActivation => new ARMRequest<pl.PaymentActivation>(this);
+            public ARMRequest<pl.Operation> Operation => new ARMRequest<pl.Operation>(this);
+            public ARMRequest<pl.Profile> Profile => new ARMRequest<pl.Profile>(this);
+            public ARMRequest<pl.BillingItem> BillingItem => new ARMRequest<pl.BillingItem>(this);
+            public ARMRequest<pl.Intent> Intent => new ARMRequest<pl.Intent>(this);
+            public ARMRequest<pl.InvoiceItem> InvoiceItem => new ARMRequest<pl.InvoiceItem>(this);
+            public ARMRequest<pl.PaymentAllocation> PaymentAllocation => new ARMRequest<pl.PaymentAllocation>(this);
+            public ARMRequest<pl.Entity> Entity => new ARMRequest<pl.Entity>(this);
+            public ARMRequest<pl.Stakeholder> Stakeholder => new ARMRequest<pl.Stakeholder>(this);
+            public ARMRequest<pl.ProcessingAgreement> ProcessingAgreement => new ARMRequest<pl.ProcessingAgreement>(this);
+            public ARMRequest<pl.Transfer> Transfer => new ARMRequest<pl.Transfer>(this);
+            public ARMRequest<pl.TransactionOperation> TransactionOperation => new ARMRequest<pl.TransactionOperation>(this);
+            public ARMRequest<pl.CheckFront> CheckFront => new ARMRequest<pl.CheckFront>(this);
+            public ARMRequest<pl.CheckBack> CheckBack => new ARMRequest<pl.CheckBack>(this);
+            public ARMRequest<pl.ProcessingRule> ProcessingRule => new ARMRequest<pl.ProcessingRule>(this);
+            public ARMRequest<pl.ProcessingSettings> ProcessingSettings => new ARMRequest<pl.ProcessingSettings>(this);
         }
     }
 }

--- a/src/PayloadTests/Fixtures.cs
+++ b/src/PayloadTests/Fixtures.cs
@@ -36,6 +36,7 @@ namespace Payload.Tests
                     state_incorporated = "NY",
                     postal_code = "11238",
                     phone_number = "(111) 222-3333",
+                    country = "US",
                     website = "https://payload.com",
                     start_date = "05/01/2015",
                     contact_name = "Test Person",
@@ -61,6 +62,7 @@ namespace Payload.Tests
                 payment_methods = new pl.PaymentMethod[]{
                     new pl.PaymentMethod(new {
                         type = "bank_account",
+                        account_holder = "Test User",
                         bank_account = new {
                             account_number = "123456789",
                             routing_number = "036001808",
@@ -82,7 +84,14 @@ namespace Payload.Tests
             var card_payment = pl.Payment.Create(new
             {
                 amount = randomNumber,
-                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
+                payment_method = new { 
+                    type = "card",
+                    card = new {
+                        card_number = "4242 4242 4242 4242", 
+                        expiry = "12/28",
+                        card_code = "123"
+                    }
+                }
             });
 
             return card_payment;
@@ -97,11 +106,14 @@ namespace Payload.Tests
             var bank_payment = pl.Payment.Create(new
             {
                 amount = randomNumber,
-                payment_method = new pl.BankAccount(new
-                {
-                    account_number = "123456789",
-                    routing_number = "036001808",
-                    account_type = "checking"
+                payment_method = new pl.PaymentMethod(new {
+                    account_holder = "Test User",
+                    type = "bank_account",
+                    bank_account = new {
+                        account_number = "123456789",
+                        routing_number = "036001808",
+                        account_type = "checking"
+                    }
                 })
             });
 

--- a/src/PayloadTests/TestApiVersioning.cs
+++ b/src/PayloadTests/TestApiVersioning.cs
@@ -1,0 +1,146 @@
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using Payload.ARM;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Payload.Tests
+{
+    public class TestApiVersioning
+    {
+        private class MockHttpMessageHandler : HttpMessageHandler
+        {
+            public HttpRequestMessage CapturedRequest { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                CapturedRequest = request;
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"object\":\"customer\",\"id\":\"cust_test123\"}")
+                };
+                return Task.FromResult(response);
+            }
+        }
+
+        [Test]
+        public void test_no_api_version_header_when_not_set()
+        {
+            var mockHandler = new MockHttpMessageHandler();
+            var session = new Payload.Session("test_key", api_version: null);
+            var request = new ARMRequest<pl.Customer>(session);
+            request._httpMessageHandler = mockHandler;
+
+            try { request.Get("cust_test123"); } catch { }
+
+            var capturedRequest = mockHandler.CapturedRequest;
+            ClassicAssert.IsNotNull(capturedRequest);
+            ClassicAssert.IsFalse(capturedRequest.Headers.Contains("X-API-Version"));
+        }
+
+        [Test]
+        public void test_api_version_header_with_other_headers()
+        {
+            var mockHandler = new MockHttpMessageHandler();
+            var session = new Payload.Session("test_key", api_version: "v2.0");
+            var request = new ARMRequest<pl.Customer>(session);
+            request._httpMessageHandler = mockHandler;
+
+            try { request.Create(new { email = "test@example.com" }); } catch { }
+
+            var capturedRequest = mockHandler.CapturedRequest;
+            ClassicAssert.IsNotNull(capturedRequest);
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("X-API-Version"));
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("Authorization"));
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("Accept"));
+            if (capturedRequest.Content != null)
+            {
+                ClassicAssert.IsNotNull(capturedRequest.Content.Headers.ContentType);
+            }
+        }
+
+        [Test]
+        [TestCase("v1.0")]
+        [TestCase("v2.1")]
+        public void test_different_api_version_values(string version)
+        {
+            var mockHandler = new MockHttpMessageHandler();
+            var session = new Payload.Session("test_key", api_version: version);
+            var request = new ARMRequest<pl.Customer>(session);
+            request._httpMessageHandler = mockHandler;
+
+            try { request.Get("cust_test123"); } catch { }
+
+            var capturedRequest = mockHandler.CapturedRequest;
+            ClassicAssert.IsNotNull(capturedRequest);
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("X-API-Version"));
+            ClassicAssert.AreEqual(version, capturedRequest.Headers.GetValues("X-API-Version").First());
+        }
+
+        [Test]
+        [TestCase("GET")]
+        [TestCase("POST")]
+        [TestCase("PUT")]
+        [TestCase("DELETE")]
+        public void test_api_version_on_all_http_methods(string httpMethod)
+        {
+            var mockHandler = new MockHttpMessageHandler();
+            var session = new Payload.Session("test_key", api_version: "v2.0");
+            var request = new ARMRequest<pl.Customer>(session);
+            request._httpMessageHandler = mockHandler;
+
+            try
+            {
+                switch (httpMethod)
+                {
+                    case "GET":
+                        request.Get("cust_test123");
+                        break;
+                    case "POST":
+                        request.Create(new { email = "test@example.com" });
+                        break;
+                    case "PUT":
+                        var customer1 = new pl.Customer(new { id = "cust_123", name = "Test" });
+                        request.UpdateAll((customer1, new { email = "new@example.com" }));
+                        break;
+                    case "DELETE":
+                        var customer2 = new pl.Customer(new { id = "cust_123", name = "Test" });
+                        request.Delete(customer2);
+                        break;
+                }
+            }
+            catch { }
+
+            var capturedRequest = mockHandler.CapturedRequest;
+            ClassicAssert.IsNotNull(capturedRequest);
+            ClassicAssert.AreEqual(httpMethod, capturedRequest.Method.Method);
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("X-API-Version"));
+            ClassicAssert.AreEqual("v2.0", capturedRequest.Headers.GetValues("X-API-Version").First());
+        }
+
+        [Test]
+        public void test_global_api_version_fallback()
+        {
+            var mockHandler = new MockHttpMessageHandler();
+            pl.ApiVersion = "v2.5";
+            var request = new ARMRequest<pl.Customer>();
+            request._httpMessageHandler = mockHandler;
+
+            try { request.Get("cust_test123"); } catch { }
+
+            var capturedRequest = mockHandler.CapturedRequest;
+            ClassicAssert.IsNotNull(capturedRequest);
+            ClassicAssert.IsTrue(capturedRequest.Headers.Contains("X-API-Version"));
+            ClassicAssert.AreEqual("v2.5", capturedRequest.Headers.GetValues("X-API-Version").First());
+            
+            pl.ApiVersion = null;
+        }
+    }
+}
+
+

--- a/src/PayloadTests/TestInvoice.cs
+++ b/src/PayloadTests/TestInvoice.cs
@@ -49,7 +49,7 @@ namespace Payload.Tests
                 account_id = cust.id,
                 card_number = "4242 4242 4242 4242",
                 default_payment_method = true,
-                expiry = "12/25",
+                expiry = "12/29",
                 card_code = "123",
                 billing_address = new
                 {

--- a/src/PayloadTests/TestTransaction.cs
+++ b/src/PayloadTests/TestTransaction.cs
@@ -86,7 +86,7 @@ namespace Payload.Tests
             {
                 amount = randomNumber,
                 description = rand_description,
-                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
+                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/29", card_code = "123"})
             });
 
             List<pl.Payment> payments = pl.Payment.FilterBy(new object[] {
@@ -147,7 +147,7 @@ namespace Payload.Tests
 
             dynamic refund = pl.Refund.Create(new
             {
-                amount = 10.0,
+                amount = 1.0,
                 ledger = new[] {
                     new pl.Ledger(new {
                         assoc_transaction_id=this.card_payment.id
@@ -156,7 +156,7 @@ namespace Payload.Tests
             });
 
             ClassicAssert.True(refund.type == "refund");
-            ClassicAssert.True(refund.amount == 10);
+            ClassicAssert.True(refund.amount == 1.0);
             ClassicAssert.True(refund.status_code == "approved");
         }
 
@@ -167,7 +167,7 @@ namespace Payload.Tests
             {
                 amount = 10.0,
                 processing_id = this.processing_account.id,
-                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
+                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/29", card_code = "123" })
             });
 
             ClassicAssert.True(refund.type == "refund");
@@ -223,7 +223,7 @@ namespace Payload.Tests
             dynamic payment = pl.Payment.Select("*", "fee", "conv_fee").Create(new
             {
                 amount = 100,
-                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/25" })
+                payment_method = new pl.Card(new { card_number = "4242 4242 4242 4242", expiry = "12/29", card_code = "123" }),
             });
 
             ClassicAssert.NotNull(payment.fee);


### PR DESCRIPTION
# Description

This PR adds API v2 support to the C# SDK, enabling version-specific API calls through the `X-API-Version` header. It also includes fixes for failing tests related to fixture data and test setup.

## Changes include:

- [x] Added API version configuration at session and global levels
- [x] Implemented `X-API-Version` HTTP header injection for versioned API calls
- [x] Added API V2 Objects
- [x] Created unit tests for API versioning
- [x] Fixed failing tests related to fixture setup and dynamic type handling

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (fixes failing tests due to fixture/type issues)
- [x] This change requires a documentation update
